### PR TITLE
Use latest order date instead of concrete delivery date

### DIFF
--- a/src/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/Business/Model/ConditionalAvailabilityExpander.php
+++ b/src/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/Business/Model/ConditionalAvailabilityExpander.php
@@ -155,6 +155,9 @@ class ConditionalAvailabilityExpander implements ConditionalAvailabilityExpander
         $sku = $itemTransfer->getSku();
         $quantity = $itemTransfer->getQuantity();
         $concreteDeliveryDate = new DateTime($itemTransfer->getDeliveryDate());
+        $latestOrderDate = $this->conditionalAvailabilityService->generateLatestOrderDateByDeliveryDate(
+            $concreteDeliveryDate
+        );
 
         if (!$groupedConditionalAvailabilities->offsetExists($sku)) {
             return $itemTransfer->addValidationMessage($this->createNotAvailableForGivenDeliveryDateMessage());
@@ -172,7 +175,7 @@ class ConditionalAvailabilityExpander implements ConditionalAvailabilityExpander
                 $endAt = new DateTime($conditionalAvailabilityPeriodTransfer->getEndAt());
                 $availableQuantity = $conditionalAvailabilityPeriodTransfer->getQuantity();
 
-                if ($concreteDeliveryDate < $startAt || $concreteDeliveryDate > $endAt || $availableQuantity < $quantity) {
+                if ($latestOrderDate < $startAt || $latestOrderDate > $endAt || $availableQuantity < $quantity) {
                     continue;
                 }
 

--- a/src/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/ConditionalAvailabilityCartConnectorDependencyProvider.php
+++ b/src/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/ConditionalAvailabilityCartConnectorDependencyProvider.php
@@ -6,7 +6,7 @@ namespace FondOfSpryker\Zed\ConditionalAvailabilityCartConnector;
 
 use FondOfSpryker\Zed\ConditionalAvailabilityCartConnector\Dependency\Facade\ConditionalAvailabilityCartConnectorToConditionalAvailabilityFacadeBridge;
 use FondOfSpryker\Zed\ConditionalAvailabilityCartConnector\Dependency\Facade\ConditionalAvailabilityCartConnectorToCustomerFacadeBridge;
-use FondOfSpryker\Zed\ConditionalAvailabilityCartConnector\Dependency\Service\ConditionalAvailabilityCartConnectorToConditionalAvailabilityService;
+use FondOfSpryker\Zed\ConditionalAvailabilityCartConnector\Dependency\Service\ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceBridge;
 use Orm\Zed\Customer\Persistence\SpyCustomerQuery;
 use Spryker\Zed\Kernel\AbstractBundleDependencyProvider;
 use Spryker\Zed\Kernel\Container;
@@ -90,7 +90,7 @@ class ConditionalAvailabilityCartConnectorDependencyProvider extends AbstractBun
     protected function addConditionalAvailabilityService(Container $container): Container
     {
         $container[static::SERVICE_CONDITIONAL_AVAILABILITY] = static function (Container $container) {
-            return new ConditionalAvailabilityCartConnectorToConditionalAvailabilityService(
+            return new ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceBridge(
                 $container->getLocator()->conditionalAvailability()->service()
             );
         };

--- a/src/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/Dependency/Service/ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceBridge.php
+++ b/src/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/Dependency/Service/ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceBridge.php
@@ -2,10 +2,11 @@
 
 namespace FondOfSpryker\Zed\ConditionalAvailabilityCartConnector\Dependency\Service;
 
+use DateTime;
 use DateTimeInterface;
 use FondOfSpryker\Service\ConditionalAvailability\ConditionalAvailabilityServiceInterface;
 
-class ConditionalAvailabilityCartConnectorToConditionalAvailabilityService implements ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceInterface
+class ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceBridge implements ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceInterface
 {
     /**
      * @var \FondOfSpryker\Service\ConditionalAvailability\ConditionalAvailabilityServiceInterface
@@ -26,5 +27,15 @@ class ConditionalAvailabilityCartConnectorToConditionalAvailabilityService imple
     public function generateEarliestDeliveryDate(): DateTimeInterface
     {
         return $this->service->generateEarliestDeliveryDate();
+    }
+
+    /**
+     * @param \DateTime $deliveryDate
+     *
+     * @return \DateTimeInterface
+     */
+    public function generateLatestOrderDateByDeliveryDate(DateTime $deliveryDate): DateTimeInterface
+    {
+        return $this->service->generateLatestOrderDateByDeliveryDate($deliveryDate);
     }
 }

--- a/src/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/Dependency/Service/ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceInterface.php
+++ b/src/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/Dependency/Service/ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceInterface.php
@@ -2,6 +2,7 @@
 
 namespace FondOfSpryker\Zed\ConditionalAvailabilityCartConnector\Dependency\Service;
 
+use DateTime;
 use DateTimeInterface;
 
 interface ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceInterface
@@ -10,4 +11,11 @@ interface ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceIn
      * @return \DateTimeInterface
      */
     public function generateEarliestDeliveryDate(): DateTimeInterface;
+
+    /**
+     * @param \DateTime $deliveryDate
+     *
+     * @return \DateTimeInterface
+     */
+    public function generateLatestOrderDateByDeliveryDate(DateTime $deliveryDate): DateTimeInterface;
 }

--- a/tests/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/Business/Model/ConditionalAvailabilityExpanderTest.php
+++ b/tests/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/Business/Model/ConditionalAvailabilityExpanderTest.php
@@ -108,7 +108,7 @@ class ConditionalAvailabilityExpanderTest extends Unit
     protected $endAt;
 
     /**
-     * @var string
+     * @var \DateTime
      */
     protected $concreteDeliveryDate;
 
@@ -182,7 +182,7 @@ class ConditionalAvailabilityExpanderTest extends Unit
 
         $this->endAt = (new DateTime())->setDate(2022, 6, 15)->format('Y-m-d');
 
-        $this->concreteDeliveryDate = (new DateTime())->setDate(2021, 6, 15)->format('Y-m-d');
+        $this->concreteDeliveryDate = new DateTime();
 
         $this->customerReference = 'customer-reference';
 
@@ -198,81 +198,85 @@ class ConditionalAvailabilityExpanderTest extends Unit
      */
     public function testExpand(): void
     {
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getItems')
             ->willReturn($this->itemTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getSku')
             ->willReturn($this->sku);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getCustomer')
             ->willReturn(null);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getCustomerReference')
             ->willReturn($this->customerReference);
 
-        $this->customerReaderInterfaceMock->expects($this->atLeastOnce())
+        $this->customerReaderInterfaceMock->expects(static::atLeastOnce())
             ->method('getCustomerByCustomerReference')
             ->with($this->customerReference)
             ->willReturn($this->customerTransferMock);
 
-        $this->customerTransferMock->expects($this->atLeastOnce())
+        $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getHasAvailabilityRestrictions')
             ->willReturn(false);
 
-        $this->conditionalAvailabilityFacadeInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityFacadeInterfaceMock->expects(static::atLeastOnce())
             ->method('findGroupedConditionalAvailabilities')
             ->willReturn($this->conditionalAvailabilityTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getDeliveryDate')
-            ->willReturn((new DateTime())->format('Y-m-d'));
+            ->willReturn($this->concreteDeliveryDate->format('Y-m-d'));
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityServiceInterfaceMock->expects(static::atLeastOnce())
+            ->method('generateLatestOrderDateByDeliveryDate')
+            ->willReturn($this->concreteDeliveryDate);
+
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn($this->quantity);
 
-        $this->conditionalAvailabilityTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityTransferMock->expects(static::atLeastOnce())
             ->method('getConditionalAvailabilityPeriodCollection')
             ->willReturn($this->conditionalAvailabilityPeriodCollectionTransferMock);
 
-        $this->conditionalAvailabilityPeriodCollectionTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodCollectionTransferMock->expects(static::atLeastOnce())
             ->method('getConditionalAvailabilityPeriods')
             ->willReturn($this->conditionalAvailabilityPeriodTransferMocks);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getStartAt')
             ->willReturn($this->startAt);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getEndAt')
             ->willReturn($this->endAt);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn($this->quantity);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDate')
             ->willReturnSelf();
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDate')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDates')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDates')
             ->willReturnSelf();
 
-        $this->assertInstanceOf(
-            QuoteTransfer::class,
+        static::assertEquals(
+            $this->quoteTransferMock,
             $this->conditionalAvailabilityExpander->expand(
                 $this->quoteTransferMock
             )
@@ -284,20 +288,20 @@ class ConditionalAvailabilityExpanderTest extends Unit
      */
     public function testExpandEmpty(): void
     {
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getItems')
             ->willReturn(new ArrayObject([]));
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDates')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDates')
             ->willReturnSelf();
 
-        $this->assertInstanceOf(
-            QuoteTransfer::class,
+        static::assertEquals(
+            $this->quoteTransferMock,
             $this->conditionalAvailabilityExpander->expand(
                 $this->quoteTransferMock
             )
@@ -309,72 +313,76 @@ class ConditionalAvailabilityExpanderTest extends Unit
      */
     public function testExpandNotAvailableForGivenQyt(): void
     {
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getItems')
             ->willReturn($this->itemTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getSku')
             ->willReturn($this->sku);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getCustomer')
             ->willReturn($this->customerTransferMock);
 
-        $this->customerTransferMock->expects($this->atLeastOnce())
+        $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getHasAvailabilityRestrictions')
             ->willReturn(false);
 
-        $this->conditionalAvailabilityFacadeInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityFacadeInterfaceMock->expects(static::atLeastOnce())
             ->method('findGroupedConditionalAvailabilities')
             ->willReturn($this->conditionalAvailabilityTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getDeliveryDate')
-            ->willReturn((new DateTime())->format('Y-m-d'));
+            ->willReturn($this->concreteDeliveryDate->format('Y-m-d'));
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityServiceInterfaceMock->expects(static::atLeastOnce())
+            ->method('generateLatestOrderDateByDeliveryDate')
+            ->willReturn($this->concreteDeliveryDate);
+
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn($this->quantity);
 
-        $this->conditionalAvailabilityTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityTransferMock->expects(static::atLeastOnce())
             ->method('getConditionalAvailabilityPeriodCollection')
             ->willReturn($this->conditionalAvailabilityPeriodCollectionTransferMock);
 
-        $this->conditionalAvailabilityPeriodCollectionTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodCollectionTransferMock->expects(static::atLeastOnce())
             ->method('getConditionalAvailabilityPeriods')
             ->willReturn($this->conditionalAvailabilityPeriodTransferMocks);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getStartAt')
             ->willReturn($this->startAt);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getEndAt')
             ->willReturn($this->endAt);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn(0);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('addValidationMessage')
             ->willReturnSelf();
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getConcreteDeliveryDate')
-            ->willReturn($this->concreteDeliveryDate);
+            ->willReturn($this->concreteDeliveryDate->format('Y-m-d'));
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDates')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDates')
             ->willReturnSelf();
 
-        $this->assertInstanceOf(
-            QuoteTransfer::class,
+        static::assertEquals(
+            $this->quoteTransferMock,
             $this->conditionalAvailabilityExpander->expand(
                 $this->quoteTransferMock
             )
@@ -386,52 +394,56 @@ class ConditionalAvailabilityExpanderTest extends Unit
      */
     public function testExpandNotAvailableForGivenDate(): void
     {
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getItems')
             ->willReturn($this->itemTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getSku')
             ->willReturn($this->sku);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getCustomer')
             ->willReturn($this->customerTransferMock);
 
-        $this->customerTransferMock->expects($this->atLeastOnce())
+        $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getHasAvailabilityRestrictions')
             ->willReturn(false);
 
-        $this->conditionalAvailabilityFacadeInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityFacadeInterfaceMock->expects(static::atLeastOnce())
             ->method('findGroupedConditionalAvailabilities')
             ->willReturn($this->conditionalAvailabilityTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getDeliveryDate')
-            ->willReturn((new DateTime())->format('Y-m-d'));
+            ->willReturn($this->concreteDeliveryDate->format('Y-m-d'));
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityServiceInterfaceMock->expects(static::atLeastOnce())
+            ->method('generateLatestOrderDateByDeliveryDate')
+            ->willReturn($this->concreteDeliveryDate);
+
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn($this->quantity);
 
-        $this->conditionalAvailabilityTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityTransferMock->expects(static::atLeastOnce())
             ->method('getConditionalAvailabilityPeriodCollection')
             ->willReturn(null);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('addValidationMessage')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDates')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDates')
             ->willReturnSelf();
 
-        $this->assertInstanceOf(
-            QuoteTransfer::class,
+        static::assertEquals(
+            $this->quoteTransferMock,
             $this->conditionalAvailabilityExpander->expand(
                 $this->quoteTransferMock
             )
@@ -443,48 +455,52 @@ class ConditionalAvailabilityExpanderTest extends Unit
      */
     public function testExpandNotAvailableForGivenDeliveryDate(): void
     {
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getItems')
             ->willReturn($this->itemTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getSku')
             ->willReturn($this->sku);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getCustomer')
             ->willReturn($this->customerTransferMock);
 
-        $this->customerTransferMock->expects($this->atLeastOnce())
+        $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getHasAvailabilityRestrictions')
             ->willReturn(false);
 
-        $this->conditionalAvailabilityFacadeInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityFacadeInterfaceMock->expects(static::atLeastOnce())
             ->method('findGroupedConditionalAvailabilities')
             ->willReturn(new ArrayObject([]));
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('addValidationMessage')
             ->willReturnSelf();
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getDeliveryDate')
-            ->willReturn((new DateTime())->format('Y-m-d'));
+            ->willReturn($this->concreteDeliveryDate->format('Y-m-d'));
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityServiceInterfaceMock->expects(static::atLeastOnce())
+            ->method('generateLatestOrderDateByDeliveryDate')
+            ->willReturn($this->concreteDeliveryDate);
+
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn($this->quantity);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDates')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDates')
             ->willReturnSelf();
 
-        $this->assertInstanceOf(
-            QuoteTransfer::class,
+        static::assertEquals(
+            $this->quoteTransferMock,
             $this->conditionalAvailabilityExpander->expand(
                 $this->quoteTransferMock
             )
@@ -496,76 +512,76 @@ class ConditionalAvailabilityExpanderTest extends Unit
      */
     public function testExpandEarliestDate(): void
     {
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getItems')
             ->willReturn($this->itemTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getSku')
             ->willReturn($this->sku);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getCustomer')
             ->willReturn($this->customerTransferMock);
 
-        $this->customerTransferMock->expects($this->atLeastOnce())
+        $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getHasAvailabilityRestrictions')
             ->willReturn(false);
 
-        $this->conditionalAvailabilityFacadeInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityFacadeInterfaceMock->expects(static::atLeastOnce())
             ->method('findGroupedConditionalAvailabilities')
             ->willReturn($this->conditionalAvailabilityTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getDeliveryDate')
             ->willReturn(ConditionalAvailabilityConstants::KEY_EARLIEST_DATE);
 
-        $this->conditionalAvailabilityServiceInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityServiceInterfaceMock->expects(static::atLeastOnce())
             ->method('generateEarliestDeliveryDate')
             ->willReturn($this->dateTime);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn($this->quantity);
 
-        $this->conditionalAvailabilityTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityTransferMock->expects(static::atLeastOnce())
             ->method('getConditionalAvailabilityPeriodCollection')
             ->willReturn($this->conditionalAvailabilityPeriodCollectionTransferMock);
 
-        $this->conditionalAvailabilityPeriodCollectionTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodCollectionTransferMock->expects(static::atLeastOnce())
             ->method('getConditionalAvailabilityPeriods')
             ->willReturn($this->conditionalAvailabilityPeriodTransferMocks);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getStartAt')
             ->willReturn($this->startAt);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getEndAt')
             ->willReturn($this->endAt);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn($this->quantity);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDate')
             ->willReturnSelf();
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDate')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDates')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDates')
             ->willReturnSelf();
 
-        $this->assertInstanceOf(
-            QuoteTransfer::class,
+        static::assertEquals(
+            $this->quoteTransferMock,
             $this->conditionalAvailabilityExpander->expand(
                 $this->quoteTransferMock
             )
@@ -577,72 +593,72 @@ class ConditionalAvailabilityExpanderTest extends Unit
      */
     public function testExpandEarliestDeliveryNotAvailableForGivenQyt(): void
     {
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getItems')
             ->willReturn($this->itemTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getSku')
             ->willReturn($this->sku);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getCustomer')
             ->willReturn($this->customerTransferMock);
 
-        $this->customerTransferMock->expects($this->atLeastOnce())
+        $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getHasAvailabilityRestrictions')
             ->willReturn(false);
 
-        $this->conditionalAvailabilityFacadeInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityFacadeInterfaceMock->expects(static::atLeastOnce())
             ->method('findGroupedConditionalAvailabilities')
             ->willReturn($this->conditionalAvailabilityTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getDeliveryDate')
             ->willReturn(ConditionalAvailabilityConstants::KEY_EARLIEST_DATE);
 
-        $this->conditionalAvailabilityServiceInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityServiceInterfaceMock->expects(static::atLeastOnce())
             ->method('generateEarliestDeliveryDate')
             ->willReturn($this->dateTime);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn($this->quantity);
 
-        $this->conditionalAvailabilityTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityTransferMock->expects(static::atLeastOnce())
             ->method('getConditionalAvailabilityPeriodCollection')
             ->willReturn($this->conditionalAvailabilityPeriodCollectionTransferMock);
 
-        $this->conditionalAvailabilityPeriodCollectionTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodCollectionTransferMock->expects(static::atLeastOnce())
             ->method('getConditionalAvailabilityPeriods')
             ->willReturn($this->conditionalAvailabilityPeriodTransferMocks);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getStartAt')
             ->willReturn($this->startAt);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getEndAt')
             ->willReturn($this->endAt);
 
-        $this->conditionalAvailabilityPeriodTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityPeriodTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn(0);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('addValidationMessage')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDates')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDates')
             ->willReturnSelf();
 
-        $this->assertInstanceOf(
-            QuoteTransfer::class,
+        static::assertEquals(
+            $this->quoteTransferMock,
             $this->conditionalAvailabilityExpander->expand(
                 $this->quoteTransferMock
             )
@@ -654,52 +670,52 @@ class ConditionalAvailabilityExpanderTest extends Unit
      */
     public function testExpandEarliestDeliveryNotAvailableForGivenDeliveryDate(): void
     {
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getItems')
             ->willReturn($this->itemTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getSku')
             ->willReturn($this->sku);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getCustomer')
             ->willReturn($this->customerTransferMock);
 
-        $this->customerTransferMock->expects($this->atLeastOnce())
+        $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getHasAvailabilityRestrictions')
             ->willReturn(false);
 
-        $this->conditionalAvailabilityFacadeInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityFacadeInterfaceMock->expects(static::atLeastOnce())
             ->method('findGroupedConditionalAvailabilities')
             ->willReturn(new ArrayObject([]));
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('addValidationMessage')
             ->willReturnSelf();
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getDeliveryDate')
             ->willReturn(ConditionalAvailabilityConstants::KEY_EARLIEST_DATE);
 
-        $this->conditionalAvailabilityServiceInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityServiceInterfaceMock->expects(static::atLeastOnce())
             ->method('generateEarliestDeliveryDate')
             ->willReturn($this->dateTime);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn($this->quantity);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDates')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDates')
             ->willReturnSelf();
 
-        $this->assertInstanceOf(
-            QuoteTransfer::class,
+        static::assertEquals(
+            $this->quoteTransferMock,
             $this->conditionalAvailabilityExpander->expand(
                 $this->quoteTransferMock
             )
@@ -711,56 +727,56 @@ class ConditionalAvailabilityExpanderTest extends Unit
      */
     public function testExpandEarliestDeliveryNotAvailableForEarliestDeliveryDate(): void
     {
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getItems')
             ->willReturn($this->itemTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getSku')
             ->willReturn($this->sku);
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('getCustomer')
             ->willReturn($this->customerTransferMock);
 
-        $this->customerTransferMock->expects($this->atLeastOnce())
+        $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getHasAvailabilityRestrictions')
             ->willReturn(false);
 
-        $this->conditionalAvailabilityFacadeInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityFacadeInterfaceMock->expects(static::atLeastOnce())
             ->method('findGroupedConditionalAvailabilities')
             ->willReturn($this->conditionalAvailabilityTransferMocks);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getDeliveryDate')
             ->willReturn(ConditionalAvailabilityConstants::KEY_EARLIEST_DATE);
 
-        $this->conditionalAvailabilityServiceInterfaceMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityServiceInterfaceMock->expects(static::atLeastOnce())
             ->method('generateEarliestDeliveryDate')
             ->willReturn($this->dateTime);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('getQuantity')
             ->willReturn($this->quantity);
 
-        $this->conditionalAvailabilityTransferMock->expects($this->atLeastOnce())
+        $this->conditionalAvailabilityTransferMock->expects(static::atLeastOnce())
             ->method('getConditionalAvailabilityPeriodCollection')
             ->willReturn(null);
 
-        $this->itemTransferMock->expects($this->atLeastOnce())
+        $this->itemTransferMock->expects(static::atLeastOnce())
             ->method('addValidationMessage')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setDeliveryDates')
             ->willReturnSelf();
 
-        $this->quoteTransferMock->expects($this->atLeastOnce())
+        $this->quoteTransferMock->expects(static::atLeastOnce())
             ->method('setConcreteDeliveryDates')
             ->willReturnSelf();
 
-        $this->assertInstanceOf(
-            QuoteTransfer::class,
+        static::assertEquals(
+            $this->quoteTransferMock,
             $this->conditionalAvailabilityExpander->expand(
                 $this->quoteTransferMock
             )

--- a/tests/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/Dependency/Service/ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceBridgeTest.php
+++ b/tests/FondOfSpryker/Zed/ConditionalAvailabilityCartConnector/Dependency/Service/ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceBridgeTest.php
@@ -6,7 +6,7 @@ use Codeception\Test\Unit;
 use DateTime;
 use FondOfSpryker\Service\ConditionalAvailability\ConditionalAvailabilityServiceInterface;
 
-class ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceTest extends Unit
+class ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceBridgeTest extends Unit
 {
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfSpryker\Service\ConditionalAvailability\ConditionalAvailabilityServiceInterface
@@ -14,12 +14,7 @@ class ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceTest e
     protected $conditionalAvailabilityServiceMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\DateTime
-     */
-    protected $dateTimeMock;
-
-    /**
-     * @var \FondOfSpryker\Zed\ConditionalAvailabilityCartConnector\Dependency\Service\ConditionalAvailabilityCartConnectorToConditionalAvailabilityService
+     * @var \FondOfSpryker\Zed\ConditionalAvailabilityCartConnector\Dependency\Service\ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceBridge
      */
     protected $conditionalAvailabilityCartConnectorToConditionalAvailabilityService;
 
@@ -32,11 +27,7 @@ class ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceTest e
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->dateTimeMock = $this->getMockBuilder(DateTime::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->conditionalAvailabilityCartConnectorToConditionalAvailabilityService = new ConditionalAvailabilityCartConnectorToConditionalAvailabilityService(
+        $this->conditionalAvailabilityCartConnectorToConditionalAvailabilityService = new ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceBridge(
             $this->conditionalAvailabilityServiceMock
         );
     }
@@ -46,13 +37,35 @@ class ConditionalAvailabilityCartConnectorToConditionalAvailabilityServiceTest e
      */
     public function testGenerateEarliestDeliveryDate(): void
     {
+        $earliestDeliveryDate = new DateTime();
+
         $this->conditionalAvailabilityServiceMock->expects(static::atLeastOnce())
             ->method('generateEarliestDeliveryDate')
-            ->willReturn($this->dateTimeMock);
+            ->willReturn($earliestDeliveryDate);
 
         static::assertEquals(
-            $this->dateTimeMock,
+            $earliestDeliveryDate,
             $this->conditionalAvailabilityCartConnectorToConditionalAvailabilityService->generateEarliestDeliveryDate()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGenerateOrderDateByDeliveryDate(): void
+    {
+        $deliveryDate = new DateTime();
+        $lastOrderDate = new DateTime();
+
+        $this->conditionalAvailabilityServiceMock->expects(static::atLeastOnce())
+            ->method('generateLatestOrderDateByDeliveryDate')
+            ->with($deliveryDate)
+            ->willReturn($lastOrderDate);
+
+        static::assertEquals(
+            $lastOrderDate,
+            $this->conditionalAvailabilityCartConnectorToConditionalAvailabilityService
+                ->generateLatestOrderDateByDeliveryDate($deliveryDate)
         );
     }
 }


### PR DESCRIPTION
- generate latest order date by concrete delivery date
- check availability date range with latest order date